### PR TITLE
Add missing bundle identifiers

### DIFF
--- a/BumbleBee.xcodeproj/project.pbxproj
+++ b/BumbleBee.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -512,6 +513,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -566,6 +568,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Bumblebee;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -586,6 +589,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Bumblebee;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -644,7 +648,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.vluxe.io.Bumblebee;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Bumblebee;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -666,7 +670,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.vluxe.io.Bumblebee;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.io.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Bumblebee;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Why:
- After building with Carthage I was getting a "LaunchServicesError, Code 0" and
  looking at the log revealed this error:
  
  ```
  Nov 28 09:12:13  com.apple.dt.Xcode[71983] <Error>: Error Domain=LaunchServicesError Code=0 "(null)" UserInfo={Error=MissingBundleIdentifier, ErrorDescription=Bundle at path /Users/jakecraige/Library/Developer/CoreSimulator/Devices/D0F5F72B-9527-426C-8B5D-17B6517B1C62/data/Library/Caches/com.apple.mobile.installd.staging/temp.pomI5K/extracted/Payload/Constable.app/Frameworks/Bumblebee.framework did not have a CFBundleIdentifier in its Info.plist}
  ```

This change addresses the need by:
- Update bundle identifiers for all targets
