### PR TITLE
Fix Indexes not being UTF16 (Emoji bug)

### DIFF
--- a/Sources/bumblebee.swift
+++ b/Sources/bumblebee.swift
@@ -86,8 +86,8 @@ open class Parser {
                             if location == NSNotFound {
                                 continue
                             }
-                            let start = mutText.index(mutText.startIndex, offsetBy: range.location)
-                            let end = mutText.index(mutText.startIndex, offsetBy: range.location + range.length)
+                            let start = mutText.utf16.index(mutText.startIndex, offsetBy: range.location)
+                            let end = mutText.utf16.index(mutText.startIndex, offsetBy: range.location + range.length)
                             
                             if let str = String(mutText.utf16[start..<end]) {
                                 let transform = opt.pattern.transform(text: str)


### PR DESCRIPTION
### 📝 Description

Having emoji breaks the parsing.  The Indexes used were not UTF16.
This is fixing the issue #28 / #29 

### 👎 Existing Behaviour
```Swift
let breakingString = " *hello* .  *hello*  cncnc cncnc  *hello*  hmm\n  *hello*  🦌🐎🦌🐎\n  *hello*  Screen Shot 2017-10-12 at 11.04.58 AM.png  *hello*  vVe2keakU8.gif  *hello*   *hello* "
```

```Swift
var parser: Parser = {
    let parser = Parser()

    parser.add(pattern: MDBoldPattern()) { (string, attributes) -> MatchedResponse in
        return MatchedResponse(string: string, attributes: [NSAttributedStringKey.font: NSFont.boldSystemFont(ofSize: 20)])
    }
    
    parser.add(pattern: MDEmphasisPattern()) { (string, attributes) -> MatchedResponse in
        return MatchedResponse(string: string, attributes: [NSAttributedStringKey.font: NSFont.boldSystemFont(ofSize: 20)])
    }
        
    return parser
}()
```
![screen shot 2018-03-09 at 8 44 48 am](https://user-images.githubusercontent.com/2945380/37176818-59503a0a-2382-11e8-8e8c-42b79783e61f.png)

### 👍 Expected Behaviour Now

<img width="320" alt="screen shot 2018-03-09 at 10 13 46 am" src="https://user-images.githubusercontent.com/2945380/37176938-c8d52f66-2382-11e8-8c9d-19332a9e17b3.png">