### PR TITLE
Allowing consumers to use their own queues

### DIFF
--- a/Sources/bumblebee.swift
+++ b/Sources/bumblebee.swift
@@ -68,10 +68,10 @@ open class Parser {
     
     //This is where the magic happens. This methods creates a attributed string
     //with all the pattern operations off the text provided
-    public func process(text: String, attributes: [NSAttributedStringKey: Any]? = nil, completion: @escaping ((NSAttributedString?) -> Void)) {
+    public func process(text: String, attributes: [NSAttributedStringKey: Any]? = nil, observedOn: DispatchQueue = .global(qos: .background), subscribedOn: DispatchQueue = .main, completion: @escaping ((NSAttributedString?) -> Void)) {
         //background operation to deal with possible long term parsing
         let opts = matchOpts //avoid race condition in the rare case that the add method is called with text is being processed
-        DispatchQueue.global(qos: .background).async {
+        observedOn.async {
             let mutStr = NSMutableAttributedString(string: text, attributes: attributes)
             for opt in opts {
                 do {
@@ -110,13 +110,13 @@ open class Parser {
                         }
                     }
                 } catch {
-                    DispatchQueue.main.async {
+                    subscribedOn.async {
                         completion(nil) //the regex failed, you get nothing! (or I guess an error if we wanted, very unlikely this will happen)
                     }
                     return
                 }
             }
-            DispatchQueue.main.async {
+            subscribedOn.async {
                 completion(mutStr)
             }
         }


### PR DESCRIPTION
We recently experienced a bug where our UI wasn't able to update asynchronously because of scrolling, upside down table views, etc... I'll spare you the details.
The point is that is was absolutely impossible to make parsing call synchronous because the completion closure was going to be called on the main thread no matter what.
This is the same queue we wanted to block because the call originated from a UI component.

TL; DR;
This PR exposes which queue to run the work and which queue to call the completion closure.
This makes it possible to make the call synchronous if needed.